### PR TITLE
fix: math proof-read corrections across chapters

### DIFF
--- a/03-linear-regression.Rmd
+++ b/03-linear-regression.Rmd
@@ -208,7 +208,7 @@ $$ Cor(x,y)^2 = \frac{(\sum_ix_iy_i)^2}{\sum_ix_i^2 \sum_iy_i^2} $$
 
 Also note that:
 
-$$\hat{y}_i = \hat\beta_o + \hat\beta_1x_i = x_i\frac{\sum_j{x_jy_j}}{\sum_jx_j^2}$$
+$$\hat{y}_i = \hat\beta_0 + \hat\beta_1x_i = x_i\frac{\sum_j{x_jy_j}}{\sum_jx_j^2}$$
 
 Therefore, given that $RSS = \sum_i(y_i - \hat{y}_i)^2$ and
 $\textit{TSS} = \sum_i(y_i - \bar{y})^2 = \sum_iy_i^2$

--- a/04-classification.Rmd
+++ b/04-classification.Rmd
@@ -41,8 +41,8 @@ Letting $x = e^{\beta_0 + \beta_1X}$
 4.12 is
 
 $$
-p_k(x) = \frac{\pi_k\frac{1}{\sqrt{2\pi\sigma}} \exp(-\frac{1}{2\sigma^2}(x - \mu_k)^2)}
-              {\sum_{l=1}^k \pi_l\frac{1}{\sqrt{2\pi\sigma}} \exp(-\frac{1}{2\sigma^2}(x - \mu_l)^2)}
+p_k(x) = \frac{\pi_k\frac{1}{\sqrt{2\pi}\sigma} \exp(-\frac{1}{2\sigma^2}(x - \mu_k)^2)}
+              {\sum_{l=1}^K \pi_l\frac{1}{\sqrt{2\pi}\sigma} \exp(-\frac{1}{2\sigma^2}(x - \mu_l)^2)}
 $$
 
 and the discriminant function is
@@ -56,15 +56,16 @@ Since $\sigma^2$ is constant
 
 $$
 p_k(x) = \frac{\pi_k \exp\left(-\frac{1}{2\sigma^2}(x - \mu_k)^2\right)}
-              {\sum_{l=1}^k \pi_l \exp\left(-\frac{1}{2\sigma^2}(x - \mu_l)^2\right)}
+              {\sum_{l=1}^K \pi_l \exp\left(-\frac{1}{2\sigma^2}(x - \mu_l)^2\right)}
 $$
 
-Maximizing $p_k(x)$ also maximizes any monotonic function of $p_k(X)$, and
-therefore, we can consider maximizing $\log(p_K(X))$
+Maximizing $p_k(x)$ also maximizes any monotonic function of $p_k(x)$, and
+therefore, we can consider maximizing $\log(p_k(x))$
 
 $$
 \log(p_k(x)) = \log(\pi_k) - \frac{1}{2\sigma^2}(x - \mu_k)^2 -
-               \log\left(\sum_{l=1}^k \pi_l \exp\left(-\frac{1}{2\sigma^2}(x - \mu_l)^2\right)\right)
+               \log\left(\sum_{l=1}^K \pi_l \exp\left(-\frac{1}{2\sigma^2}(x - \mu_l)^2\right)\right)
+$$
 $$
 
 Remember that we are maximizing over $k$, and since the last term does not
@@ -103,19 +104,19 @@ $$
 As above,
 
 $$
-p_k(x) = \frac{\pi_k\frac{1}{\sqrt{2\pi\sigma_k}} \exp(-\frac{1}{2\sigma_k^2}(x - \mu_k)^2)}
-              {\sum_{l=1}^k \pi_l\frac{1}{\sqrt{2\pi\sigma_l}} \exp(-\frac{1}{2\sigma_l^2}(x - \mu_l)^2)}
+p_k(x) = \frac{\pi_k\frac{1}{\sqrt{2\pi}\sigma_k} \exp(-\frac{1}{2\sigma_k^2}(x - \mu_k)^2)}
+              {\sum_{l=1}^K \pi_l\frac{1}{\sqrt{2\pi}\sigma_l} \exp(-\frac{1}{2\sigma_l^2}(x - \mu_l)^2)}
 $$
 
 Now lets derive the Bayes classifier, without assuming 
 $\sigma_1^2 = ... = \sigma_K^2$
 
-Maximizing $p_k(x)$ also maximizes any monotonic function of $p_k(X)$, and
-therefore, we can consider maximizing $\log(p_K(X))$
+Maximizing $p_k(x)$ also maximizes any monotonic function of $p_k(x)$, and
+therefore, we can consider maximizing $\log(p_k(x))$
 
 $$
-\log(p_k(x)) = \log(\pi_k) + \log\left(\frac{1}{\sqrt{2\pi\sigma_k}}\right) - \frac{1}{2\sigma_k^2}(x - \mu_k)^2 -
-              \log\left(\sum_{l=1}^k \frac{1}{\sqrt{2\pi\sigma_l}} \pi_l \exp\left(-\frac{1}{2\sigma_l^2}(x - \mu_l)^2\right)\right)
+\log(p_k(x)) = \log(\pi_k) + \log\left(\frac{1}{\sqrt{2\pi}\sigma_k}\right) - \frac{1}{2\sigma_k^2}(x - \mu_k)^2 -
+              \log\left(\sum_{l=1}^K \frac{1}{\sqrt{2\pi}\sigma_l} \pi_l \exp\left(-\frac{1}{2\sigma_l^2}(x - \mu_l)^2\right)\right)
 $$
 
 Remember that we are maximizing over $k$, and since the last term does not

--- a/06-linear-model-selection-and-regularization.Rmd
+++ b/06-linear-model-selection-and-regularization.Rmd
@@ -357,8 +357,8 @@ abline(v = y - lambda / 2, lty = 2)
 \begin{align*}
 \mathcal{L} 
   &= \prod_i^n \mathcal{N}(0, \sigma^2) \\
-  &= \prod_i^n \frac{1}{\sqrt{2\pi\sigma}}\exp\left(-\frac{\epsilon_i^2}{2\sigma^2}\right) \\
-  &= \left(\frac{1}{\sqrt{2\pi\sigma}}\right)^n \exp\left(-\frac{1}{2\sigma^2} \sum_i^n \epsilon_i^2\right)
+  &= \prod_i^n \frac{1}{\sqrt{2\pi}\sigma}\exp\left(-\frac{\epsilon_i^2}{2\sigma^2}\right) \\
+  &= \left(\frac{1}{\sqrt{2\pi}\sigma}\right)^n \exp\left(-\frac{1}{2\sigma^2} \sum_i^n \epsilon_i^2\right)
 \end{align*}
 
 > b. Assume the following prior for $\beta$: $\beta_1, ..., \beta_p$ are

--- a/07-moving-beyond-linearity.Rmd
+++ b/07-moving-beyond-linearity.Rmd
@@ -35,14 +35,14 @@ $a_1 = \beta_0$, $b_1 = \beta_1$, $c_1 = \beta_2$, $d_1 = \beta_3$
 For $x \gt \xi$, the cubic polynomial would be (we include the $\beta_4$ term).
 \begin{align}
 f(x) = & \beta_0 + \beta_1x + \beta_2x^2 + \beta_3x^3 + \beta_4(x-\xi)^3 \\
-     = & \beta_0 + \beta_1x + \beta_2x^2 +  + \beta_4(x^3 - 3x^2\xi + 3x\xi^2 -\xi^3) \\
+     = & \beta_0 + \beta_1x + \beta_2x^2 + \beta_3x^3 + \beta_4(x^3 - 3x^2\xi + 3x\xi^2 -\xi^3) \\
      = & \beta_0 - \beta_4\xi^3 + (\beta_1 + 3\beta_4\xi^2)x +
          (\beta_2 - 3\beta_4\xi)x^2 + (\beta_3 + \beta_4)x^3
 \end{align}
 
 Therefore,
-$a_1 = \beta_0 - \beta_4\xi^3$, $b_1 = \beta_1 + 3\beta_4\xi^2$,
-$c_1 = \beta_2 - 3\beta_4\xi$, $d_1 = \beta_3 + \beta_4$
+$a_2 = \beta_0 - \beta_4\xi^3$, $b_2 = \beta_1 + 3\beta_4\xi^2$,
+$c_2 = \beta_2 - 3\beta_4\xi$, $d_2 = \beta_3 + \beta_4$
 
 > c. Show that $f_1(\xi) = f_2(\xi)$. That is, $f(x)$ is continuous at $\xi$.
 
@@ -65,7 +65,7 @@ f_2(\xi) = & \beta_0 - \beta_4\xi^3 + (\beta_1 + 3\beta_4\xi^2)\xi +
 To do this we differentiate the above with respect to $x$.
 
 $$
-f_1'(x) = \beta_1 + 2\beta_2x + 3\beta_3x^2
+f_1'(x) = \beta_1 + 2\beta_2x + 3\beta_3x^2 \\
 f_1'(\xi) = \beta_1 + 2\beta_2\xi + 3\beta_3\xi^2
 $$
 
@@ -81,8 +81,8 @@ f_2'(\xi) & = \beta_1 + 3\beta_4\xi^2 + 2(\beta_2 - 3\beta_4\xi)\xi + 3(\beta_3 
 > Therefore, $f(x)$ is indeed a cubic spline.
 
 $$
-f_1'(x) = 2\beta_2x + 6\beta_3x \\
-f_1''(\xi) = 2\beta_2\xi + 6\beta_3\xi
+f_1''(x) = 2\beta_2 + 6\beta_3 x \\
+f_1''(\xi) = 2\beta_2 + 6\beta_3 \xi
 $$
 
 $$

--- a/10-deep-learning.Rmd
+++ b/10-deep-learning.Rmd
@@ -120,25 +120,28 @@ Pr(Y=k|X=x) = \frac
 {\sum_{l=1}^K e^{\beta_{l0} + \beta_{l1}x1 + ... + \beta_{lp}x_p}}
 $$
 
-adding constants $c_j$ to each class gives:
+adding constants $c_j$ to the coefficients $\beta_{kj}$ for every class $k$
+gives:
 
 \begin{align*}
 Pr(Y=k|X=x) 
 &= \frac
-  {e^{\beta_{K0} + \beta_{K1}x_1 + c_1 + ... + \beta_{Kp}x_p + c_p}}
-  {\sum_{l=1}^K e^{\beta_{l0} + \beta_{l1}x1 + c_1 + ... + \beta_{lp}x_p + c_p}} \\
+  {e^{(\beta_{k0} + c_0) + (\beta_{k1} + c_1)x_1 + ... + (\beta_{kp} + c_p)x_p}}
+  {\sum_{l=1}^K e^{(\beta_{l0} + c_0) + (\beta_{l1} + c_1)x_1 + ... + (\beta_{lp} + c_p)x_p}} \\
 &= \frac
-  {e^{c1 + ... + c_p}e^{\beta_{K0} + \beta_{K1}x_1 + ... + \beta_{Kp}x_p}}
-  {\sum_{l=1}^K e^{c1 + ... + c_p}e^{\beta_{l0} + \beta_{l1}x1 + ... + \beta_{lp}x_p}} \\
+  {e^{c_0 + c_1 x_1 + ... + c_p x_p} \, e^{\beta_{k0} + \beta_{k1}x_1 + ... + \beta_{kp}x_p}}
+  {\sum_{l=1}^K e^{c_0 + c_1 x_1 + ... + c_p x_p} \, e^{\beta_{l0} + \beta_{l1}x_1 + ... + \beta_{lp}x_p}} \\
 &= \frac
-  {e^{c1 + ... + c_p}e^{\beta_{K0} + \beta_{K1}x_1 + ... + \beta_{Kp}x_p}}
-  {e^{c1 + ... + c_p}\sum_{l=1}^K e^{\beta_{l0} + \beta_{l1}x1 + ... + \beta_{lp}x_p}} \\
+  {e^{c_0 + c_1 x_1 + ... + c_p x_p} \, e^{\beta_{k0} + \beta_{k1}x_1 + ... + \beta_{kp}x_p}}
+  {e^{c_0 + c_1 x_1 + ... + c_p x_p} \sum_{l=1}^K e^{\beta_{l0} + \beta_{l1}x_1 + ... + \beta_{lp}x_p}} \\
 &= \frac
-  {e^{\beta_{K0} + \beta_{K1}x_1 + ... + \beta_{Kp}x_p}}
-  {\sum_{l=1}^K e^{\beta_{l0} + \beta_{l1}x1 + ... + \beta_{lp}x_p}} \\
+  {e^{\beta_{k0} + \beta_{k1}x_1 + ... + \beta_{kp}x_p}}
+  {\sum_{l=1}^K e^{\beta_{l0} + \beta_{l1}x_1 + ... + \beta_{lp}x_p}} \\
 \end{align*}
 
-which collapses to 4.13 (with the same argument as above).
+The key step is that $e^{c_0 + c_1 x_1 + ... + c_p x_p}$ depends on $x$ but
+*not* on the class $l$, so it factors out of the sum in the denominator and
+cancels with the same factor in the numerator. We recover 4.13.
 
 > This shows that the softmax function is _over-parametrized_. However,
 > regularization and SGD typically constrain the solutions so that this is not a

--- a/13-multiple-testing.Rmd
+++ b/13-multiple-testing.Rmd
@@ -35,12 +35,12 @@ For independent tests this is $\alpha + \alpha - \alpha^2$
 >    _Hint: First, suppose that the two p-values are perfectly correlated._
 
 If they were perfectly correlated, we would effectively be performing a single
-test (thus FWER would be $alpha$). In the case when they are positively
+test (thus FWER would be $\alpha$). In the case when they are positively
 correlated therefore, we can expect the FWER to be less than in b.
 
-Alternatively, as above, FWEW = Pr(A ∪ B) = Pr(A) + Pr(B) - Pr(A ∩ B).
+Alternatively, as above, FWER = Pr(A ∪ B) = Pr(A) + Pr(B) - Pr(A ∩ B).
 For perfectly positively correlated tests Pr(A ∩ B) = $\alpha$, so the 
-FWEW is $\alpha$ which is smaller than b.
+FWER is $\alpha$ which is smaller than b.
 
 > d. Suppose again that $m = 2$, but that now the p-values for the two tests are
 >    negatively correlated, so that if one is large then the other will tend to
@@ -52,7 +52,7 @@ FWEW is $\alpha$ which is smaller than b.
 >    _never reject both null hypotheses._
 
 Taking the equation above, for two tests,
-FWEW = Pr(A ∪ B) = Pr(A) + Pr(B) - Pr(A ∩ B). In the case considered in the
+FWER = Pr(A ∪ B) = Pr(A) + Pr(B) - Pr(A ∩ B). In the case considered in the
 hint Pr(A ∩ B) = 0, so Pr(A ∪ B) = $2\alpha$, which is larger than b.
 
 ### Question 2


### PR DESCRIPTION
- ch3 Q7: typo \hat\beta_o -> \hat\beta_0
- ch4 Q2,Q3: \sum_{l=1}^k -> \sum_{l=1}^K; \sqrt{2\pi\sigma} ->
  \sqrt{2\pi}\sigma; consistent x/k case in log derivation
- ch6 Q7: \sqrt{2\pi\sigma} -> \sqrt{2\pi}\sigma in normal likelihood
- ch7 Q1(b): re-label a_1..d_1 as a_2..d_2 for the x>xi piece; drop stray '+ +' in expansion
- ch7 Q1(e): correct f_1''(x) = 2\beta_2 + 6\beta_3 x (was missing constant term and used wrong derivative label)
- ch7 Q1(d): missing newline between f_1'(x) and f_1'(xi)
- ch10 Q2(b): include x_j factors when adding c_j to coefficients; previously the algebra wrote e^{c_1+...+c_p} without the x_j multipliers, which is the wrong factorisation (the final cancellation still works, but only when the constants depend on x)
- ch13 Q1(c,d): FWEW -> FWER; missing backslash in $alpha$