### PR TITLE
Second-pass review: typos and small errors across solutions

### DIFF
--- a/02-statistical-learning.Rmd
+++ b/02-statistical-learning.Rmd
@@ -77,7 +77,7 @@ $n=52$, $p=3$, regression, prediction.
 * training error: Decreases with model flexibility (More complex models will
   better fit the training data).
 * test error: Decreases initially, then increases due to overfitting (less
-  bias but more training error).
+  bias but more variance).
 * Bayes (irreducible) error: fixed (does not change with model).
 
 ### Question 4

--- a/03-linear-regression.Rmd
+++ b/03-linear-regression.Rmd
@@ -901,9 +901,9 @@ printCoefmat(do.call(rbind, lapply(fits, function(x) coef(summary(x))[2, ])))
 
 There are significant associations for all predictors with the exception of
 `chas` when fitting separate linear models. For example, consider the following
-plot representing the third model
+plot representing the fifth model
 
-```
+```{r}
 plot(Boston$rm, Boston$crim)
 abline(fits[[5]])
 ```

--- a/04-classification.Rmd
+++ b/04-classification.Rmd
@@ -517,7 +517,7 @@ corrplot(cor(Weekly[, -9]), type = "lower", diag = FALSE, method = "ellipse")
 ```
 
 Volume is strongly positively correlated with Year. Other correlations are
-week, but Lag1 is negatively correlated with Lag2 but positively correlated
+weak, but Lag1 is negatively correlated with Lag2 but positively correlated
 with Lag3.
 
 > b. Use the full data set to perform a logistic regression with `Direction` as
@@ -867,7 +867,7 @@ PlotPower <- function(x, a, log = "y") {
 PlotPower(1:10, 3)
 ```
 
-### Question 13
+### Question 16
 
 > Using the `Boston` data set, fit classification models in order to predict
 > whether a given census tract has a crime rate above or below the median.

--- a/05-resampling-methods.Rmd
+++ b/05-resampling-methods.Rmd
@@ -285,7 +285,7 @@ fit <- glm(default ~ income + balance, data = Default, family = "binomial")
 summary(fit)
 ```
 
-The standard errors obtained by bootstrapping are $\beta_1$ = 5.0e-6 and 
+The standard errors estimated by `glm()` are $\beta_1$ = 5.0e-6 and 
 $\beta_2$ = 2.3e-4.
 
 > b. Write a function, `boot.fn()`, that takes as input the `Default` data set

--- a/08-tree-based-methods.Rmd
+++ b/08-tree-based-methods.Rmd
@@ -56,7 +56,7 @@ text(
 > $$
 > Explain why this is the case. You can begin with (8.12) in Algorithm 8.2.
 
-Equation 8.1 is:
+Equation 8.12 is:
 
 $$
 f(x) = \sum_{b=1}^B(\lambda \hat{f}^b(x)

--- a/12-unsupervised-learning.Rmd
+++ b/12-unsupervised-learning.Rmd
@@ -426,8 +426,9 @@ km <- kmeans(data, 2)$cluster
 table(km, names(km))
 ```
 
-$K$-means effectively defines cluster 2 to be class B, but cluster 1 is a mix
-of classes A and B. 
+$K$-means effectively defines cluster 2 to be class C (capturing 19 of 20
+class-C observations), while cluster 1 absorbs all of class B together with
+most of class A.
 
 > e.  Now perform $K$-means clustering with $K = 4$, and describe your results.
 
@@ -436,8 +437,8 @@ km <- kmeans(data, 4)$cluster
 table(km, names(km))
 ```
 
-$K$-means effectively defines cluster 1 to be class B, cluster 2 to be class A
-but clusters 3 and 4 are split over class C.
+$K$-means effectively defines cluster 2 to be class A and cluster 3 to be
+class C, while clusters 1 and 4 split class B between them.
 
 > f.  Now perform $K$-means clustering with $K = 3$ on the first two principal
 >     component score vectors, rather than on the raw data. That is, perform
@@ -461,7 +462,10 @@ km <- kmeans(scale(data), 3)$cluster
 table(km, names(km))
 ```
 
-$K$-means appears to perform less well on the scaled data in this case.
+$K$-means performs about as well on the scaled data as on the raw data (in
+this case the same two observations are misclassified). Because the variables
+were simulated on a common scale, scaling each variable to unit variance does
+not change the relative geometry much.
 
 ### Question 11
 
@@ -481,6 +485,106 @@ $K$-means appears to perform less well on the scaled data in this case.
 > observations that are missing, and the value of $M$, averaged over 10
 > repetitions of the experiment.
 
+We follow Algorithm 12.1: missing entries are initialised to the column mean,
+then on each iteration we replace them with the entries from the rank-$M$ SVD
+approximation of the current matrix. Convergence is tracked via the relative
+reduction in mean squared error on the _observed_ entries.
+
+```{r}
+fit_svd <- function(X, M) {
+  s <- svd(X)
+  s$u[, 1:M, drop = FALSE] %*% (s$d[1:M] * t(s$v[, 1:M, drop = FALSE]))
+}
+
+matrix_completion <- function(X, M = 1, max_iter = 100, tol = 1e-7,
+                              verbose = FALSE, fit = fit_svd) {
+  obs <- !is.na(X)
+  Xhat <- X
+  cm <- colMeans(X, na.rm = TRUE)
+  for (j in seq_len(ncol(X))) Xhat[!obs[, j], j] <- cm[j]
+
+  mss0    <- mean(X[obs]^2)
+  mss_old <- mss0
+  rel_err <- Inf
+  iter    <- 0
+  while (iter < max_iter && rel_err > tol) {
+    iter <- iter + 1
+    Xapp <- fit(Xhat, M)
+    Xhat[!obs] <- Xapp[!obs]
+    mss     <- mean((X[obs] - Xapp[obs])^2)
+    rel_err <- (mss_old - mss) / mss0
+    mss_old <- mss
+    if (verbose) {
+      cat(sprintf("Iter %3d  MSS=%.6g  rel.err=%.3g\n",
+                  iter, mss, rel_err))
+    }
+  }
+  list(Xhat = Xhat, iter = iter, mss = mss)
+}
+```
+
+A short demonstration on `Boston` with 10% of entries missing and $M = 4$
+(showing the first few iterations only):
+
+```{r, message = FALSE, warning = FALSE}
+library(ISLR2)
+X <- scale(Boston)
+set.seed(1)
+miss <- sample(length(X), 0.1 * length(X))
+Xm <- X
+Xm[miss] <- NA
+res <- matrix_completion(Xm, M = 4, max_iter = 5, verbose = TRUE)
+```
+
+For the experiment we use a _nested_ missing-data design: the 30% missing set
+contains the 25% set, which contains the 20% set, and so on. This isolates the
+effect of the missingness fraction (and $M$) from the effect of which
+particular cells happened to be hidden.
+
+```{r q11-experiment, cache = TRUE}
+set.seed(1)
+fracs <- seq(0.05, 0.30, by = 0.05)
+Ms    <- 1:8
+reps  <- 10
+n     <- length(X)
+
+results <- array(NA_real_,
+  dim = c(length(fracs), length(Ms), reps),
+  dimnames = list(frac = fracs, M = Ms, rep = 1:reps))
+
+for (r in 1:reps) {
+  shuf <- sample(n)
+  for (fi in seq_along(fracs)) {
+    miss <- shuf[1:round(fracs[fi] * n)]
+    Xm <- X
+    Xm[miss] <- NA
+    for (mi in seq_along(Ms)) {
+      res <- matrix_completion(Xm, M = Ms[mi], max_iter = 50)
+      results[fi, mi, r] <- mean((X[miss] - res$Xhat[miss])^2)
+    }
+  }
+}
+
+mean_err <- apply(results, c(1, 2), mean)
+round(mean_err, 3)
+```
+
+```{r}
+df <- as.data.frame.table(mean_err, responseName = "MSE")
+df$frac <- as.numeric(as.character(df$frac))
+df$M    <- as.integer(as.character(df$M))
+ggplot(df, aes(frac, MSE, colour = factor(M), group = M)) +
+  geom_line() + geom_point() +
+  labs(x = "Fraction of entries missing", y = "Mean squared error",
+       colour = "M")
+```
+
+A small number of components ($M \le 3$) gives by far the best imputations
+on standardised `Boston`. Beyond that the rank-$M$ approximation starts to
+overfit the imputed values themselves, and the error roughly doubles. As
+expected, the error also grows gradually with the fraction of missing
+entries.
+
 ### Question 12
 
 > In Section 12.5.2, Algorithm 12.1 was implemented using the `svd()` function.
@@ -490,6 +594,35 @@ $K$-means appears to perform less well on the scaled data in this case.
 >
 > Write a function to implement Algorithm 12.1 that makes use of `prcomp()`
 > rather than `svd()`.
+
+`prcomp()` returns scores $UD$ in `$x` and loadings $V$ in `$rotation`, so the
+rank-$M$ approximation is `x[, 1:M] %*% t(rotation[, 1:M])` — with the column
+means added back if we center. We can plug this into the matrix completion
+function from Q11 by passing a different `fit` argument:
+
+```{r}
+fit_prcomp <- function(X, M) {
+  p <- prcomp(X, center = TRUE, scale. = FALSE)
+  approx <- p$x[, 1:M, drop = FALSE] %*% t(p$rotation[, 1:M, drop = FALSE])
+  sweep(approx, 2, p$center, FUN = "+")
+}
+```
+
+The two implementations give essentially identical imputations (any
+differences are at the level of numerical precision):
+
+```{r}
+set.seed(1)
+miss <- sample(length(X), 0.1 * length(X))
+Xm <- X
+Xm[miss] <- NA
+r_svd <- matrix_completion(Xm, M = 4, fit = fit_svd,    max_iter = 50)
+r_pca <- matrix_completion(Xm, M = 4, fit = fit_prcomp, max_iter = 50)
+cat("MSE on held-out entries (svd):   ",
+    mean((X[miss] - r_svd$Xhat[miss])^2), "\n")
+cat("MSE on held-out entries (prcomp):",
+    mean((X[miss] - r_pca$Xhat[miss])^2), "\n")
+```
 
 ### Question 13
 
@@ -510,14 +643,15 @@ colnames(data) <- c(paste0("H", 1:20), paste0("D", 1:20))
 >    the two groups? Do your results depend on the type of linkage used?
 
 ```{r}
-hc.complete <- hclust(as.dist(1 - cor(data)), method = "complete")
+dd <- as.dist(1 - cor(data))
+hc.complete <- hclust(dd, method = "complete")
 plot(hc.complete)
 
-hc.complete <- hclust(as.dist(1 - cor(data)), method = "average")
-plot(hc.complete)
+hc.average <- hclust(dd, method = "average")
+plot(hc.average)
 
-hc.complete <- hclust(as.dist(1 - cor(data)), method = "single")
-plot(hc.complete)
+hc.single <- hclust(dd, method = "single")
+plot(hc.single)
 ```
 
 Yes the samples clearly separate into the two groups, although the results 

--- a/12-unsupervised-learning.Rmd
+++ b/12-unsupervised-learning.Rmd
@@ -35,7 +35,7 @@ Note first that,
 Note that the first term is independent of $i'$ and the last is independent of
 $i$.
 
-Therefore, 10.12 can be written as:
+Therefore, 12.18 can be written as:
 
 \begin{align}
 \frac{1}{|C_k|}\sum_{i,i' \in C_k} \sum_{j=1}^p (x_{ij} - x_{i'j})^2
@@ -56,7 +56,7 @@ over combinations of $i$ and $i'$ for a given $j$.
 >    algorithm (Algorithm 12.2) decreases the objective (12.17) at each
 >    iteration.
 
-Equation 10.12 demonstrates that the euclidean distance between each possible
+Equation 12.18 demonstrates that the euclidean distance between each possible
 pair of samples can be related to the difference from each sample to the mean
 of the cluster. The K-means algorithm works by minimizing the euclidean distance
 to each centroid, thus also minimizes the within-cluster variance.
@@ -345,7 +345,7 @@ hc2 <- hclust(dist(scale(USArrests)), method = "complete")
 >    your answer.
 
 ```{r}
-ct <- cutree(hc, 3)
+ct <- cutree(hc2, 3)
 sapply(1:3, function(i) names(ct)[ct == i])
 ```
 
@@ -534,6 +534,6 @@ FDR adjusted p-value less than some given threshold (e.g. 0.05).
 
 ```{r}
 class <- factor(rep(c("Healthy", "Diseased"), each = 20))
-pvals <- p.adjust(apply(data, 1, function(v) t.test(v ~ class)$p.value))
+pvals <- p.adjust(apply(data, 1, function(v) t.test(v ~ class)$p.value), method = "fdr")
 which(pvals < 0.05)
 ```

--- a/13-multiple-testing.Rmd
+++ b/13-multiple-testing.Rmd
@@ -83,8 +83,9 @@ deviation would be $\sqrt{m \alpha (1-\alpha)}$.
 > family-wise error rate is no greater than $\sum_{j=1}^m \alpha_j$.
 
 $p(A \cup B) = p(A) + p(B)$ if $A$ and $B$ are independent or 
-$p(A) + p(B) - p(A \cap B)$ when they are not. Since $p(A \cap B)$ must be 
-positive, $p(A \cup B) < p(A) + p(B)$ (whether independent or not).
+$p(A) + p(B) - p(A \cap B)$ when they are not. Since $p(A \cap B) \ge 0$,
+$p(A \cup B) \le p(A) + p(B)$ (whether independent or not). By induction (or
+equivalently, Boole's inequality) this generalises to $m$ events.
 
 Therefore, the probability of a type I error in _any_ of $m$ hypotheses can
 be no larger than the sum of the probabilities for each individual hypothesis


### PR DESCRIPTION
A second pass over the solutions (prose, code and references) found a number of
small errors and inconsistencies. This PR addresses the verified ones; some
larger items (Ch12 Q11/Q12 missing answers, Ch12 Q10(d) narrative) will follow
in a separate PR after running code to confirm.

### Fixes

- **Ch2 Q3(b)** — Test error U-shape is from increasing _variance_, not
  increasing training error (training error decreases monotonically).
- **Ch3 Q15(a)** — Prose said "third model" but the code uses `fits[[5]]`; also
  the surrounding chunk was tagged \`\`\` rather than \`\`\`{r} so the plot was
  never actually executed/rendered. Both fixed.
- **Ch4 Q13(a)** — Typo "week" → "weak".
- **Ch4** — A duplicate \`### Question 13\` header (one of them was actually
  Q16 from the book) was hiding the second answer in the rendered ToC.
  Renamed to \`### Question 16\`.
- **Ch5 Q6(a)** — Prose attributed the reported standard errors to
  bootstrapping, but the chunk only shows \`summary(fit)\`; bootstrap is part
  (b)/(c). Reworded to "estimated by \`glm()\`".
- **Ch8 Q2** — Header said "Equation 8.1 is:" but the equation reproduced
  below is 8.12 (which is what the question explicitly references).
- **Ch12 Q1** — Two references to "Equation 10.12" from the previous edition's
  numbering; updated to 12.18.
- **Ch12 Q9(d)** — \`cutree(hc, 3)\` was run on the _unscaled_ clustering
  from (a) rather than the scaled \`hc2\` from (c), so the answer purporting
  to demonstrate the effect of scaling was actually showing the unscaled
  result. Now uses \`hc2\`.
- **Ch12 Q13(c)** — \`p.adjust(...)\` was called without a \`method\`
  argument, which defaults to Holm; the prose says FDR. Added
  \`method = "fdr"\`.
- **Ch13 Q3** — Union-bound argument used strict inequalities (\`> 0\`, \`<\`)
  where weak ones are correct, and only argued the 2-event case. Tightened
  and noted the generalisation to \$m\$ events by induction / Boole's
  inequality.