### PR TITLE
content: fill in missing answers (ch2 Q3a, ch2 Q10c, ch3 Q10b, ch5 Q7d)

### DIFF
--- a/02-statistical-learning.Rmd
+++ b/02-statistical-learning.Rmd
@@ -70,6 +70,30 @@ $n=52$, $p=3$, regression, prediction.
 > b. Explain why each of the five curves has the shape displayed in
 >    part (a).
 
+```{r}
+library(ggplot2)
+library(tidyr)
+
+flex <- seq(0, 1, length.out = 200)
+curves <- data.frame(
+  flex,
+  `(squared) bias` = 4 * (1 - flex)^2 + 0.2,
+  variance = 0.2 + 4 * flex^3,
+  `training error` = 4.5 * (1 - flex) + 0.3,
+  `Bayes error` = 1,
+  check.names = FALSE
+)
+curves$`test error` <-
+  curves$`(squared) bias` + curves$variance + curves$`Bayes error`
+
+ggplot(
+  pivot_longer(curves, -flex, names_to = "curve", values_to = "value"),
+  aes(flex, value, color = curve)
+) +
+  geom_line(linewidth = 1) +
+  labs(x = "Flexibility", y = "Error", color = NULL)
+```
+
 * (squared) bias: Decreases with increasing flexibility (Generally, more
   flexible methods result in less bias).
 * variance: Increases with increasing flexibility (In general, more flexible
@@ -435,7 +459,20 @@ heatmap(cor(Boston, method = "spearman"), cexRow = 1.1, cexCol = 1.1)
 > c. Are any of the predictors associated with per capita crime rate? If so,
 >    explain the relationship.
 
-Yes
+Yes. Inspecting the Spearman correlations with `crim`:
+
+```{r}
+sort(cor(Boston, method = "spearman")["crim", ])
+```
+
+Crime rate rises strongly with `nox` (air pollution), `indus` (proportion of
+non-retail business), `tax`, `rad` (highway accessibility), `age` (proportion
+of old housing) and `lstat` ("lower-status" population) -- i.e. with the
+features that mark dense, industrial, lower-income tracts. It falls with
+`dis` (distance to employment centers), `zn` (large-lot residential zoning),
+and `medv` (median home value) -- the features that mark wealthier, more
+suburban areas. `chas` (bordering the Charles river) shows essentially no
+association.
 
 > d. Do any of the census tracts of Boston appear to have particularly high 
 >    crime rates? Tax rates? Pupil-teacher ratios? Comment on the range of each

--- a/03-linear-regression.Rmd
+++ b/03-linear-regression.Rmd
@@ -400,6 +400,17 @@ fit <- lm(Sales ~ Price + Urban + US, data = Carseats)
 summary(fit)
 ```
 
+The coefficients are interpreted with the other predictors held fixed:
+
+* `(Intercept)` $\approx 13.04$: expected `Sales` (thousands of units) for a
+  non-urban, non-US store with `Price` of 0.
+* `Price` $\approx -0.054$: each one-dollar increase in `Price` is associated
+  with about 54 fewer units sold. Strongly significant.
+* `UrbanYes` $\approx -0.022$: urban stores sell about 22 fewer units than
+  non-urban stores. Not significant.
+* `USYes` $\approx 1.20$: US stores sell about 1200 more units than non-US
+  stores. Strongly significant.
+
 > c. Write out the model in equation form, being careful to handle the
 >    qualitative variables properly.
 

--- a/05-resampling-methods.Rmd
+++ b/05-resampling-methods.Rmd
@@ -368,7 +368,8 @@ error <- numeric(nrow(Weekly))
 for (i in seq_len(nrow(Weekly))) {
   fit <- glm(Direction ~ Lag1 + Lag2, data = Weekly[-i, ], family = "binomial")
   p <- predict(fit, newdata = Weekly[i, , drop = FALSE], type = "response") > 0.5
-  error[i] <- ifelse(p, "Down", "Up") == Weekly$Direction[i]
+  pred <- ifelse(p, "Up", "Down")
+  error[i] <- pred != Weekly$Direction[i]
 }
 ```
 


### PR DESCRIPTION
Audit of every \`### Question\` body in the book turned up a few real gaps and one obscure (but actually correct) snippet. This PR fixes them; everything else looks broadly answered and correct.

### Fixes

| Where | Before | After |
| --- | --- | --- |
| [ch2 Q3(a)](02-statistical-learning.Rmd#L59) | Prose description of the five curves but no plot | Add the ggplot sketch the prompt explicitly asks for. |
| [ch2 Q10(c)](02-statistical-learning.Rmd#L443) | One-word "Yes" | Spearman correlations + a per-predictor description of which features mark high-crime tracts. |
| [ch3 Q10(b)](03-linear-regression.Rmd#L398) | Just \`summary(fit)\` output | Add the prose interpretation of each coefficient (Intercept / Price / UrbanYes / USYes) with sign, magnitude and significance. |
| [ch5 Q7(d)](05-resampling-methods.Rmd#L367) | \`ifelse(p, "Down", "Up") == truth\` (double-inverted; correct by accident) | \`pred <- ifelse(p, "Up", "Down"); error[i] <- pred != truth\` (same numeric result, readable logic). LOOCV mean error stays at 0.45. |

### Audit method

Two scripts at \`/tmp/find_unanswered{,_subparts}.R\` looked for question / sub-part bodies that contain less than 15 chars of non-blockquote prose. After filtering false positives (roman-numeral MCQ options, code lines whose first token happened to be a single letter), the four items above are the only real gaps. Everything else in chapters 2–13 has substantive answers.

### Stacking

Based on \`ci/quality-gates\` (PR #24) because it uses the consolidated WORDLIST. After #24 and #25 merge, this can be retargeted at \`main\`.

Local spell-check + lint pass; chapter render check passes.