### PR TITLE
ci(renv): install Ubuntu sysdeps and use PPM Linux binaries

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,9 +8,31 @@ permissions:
 jobs:
   build-and-deploy:
     concurrency: ci-${{ github.ref }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    env:
+      # Tell renv to fetch pre-built Linux binaries from Posit Public Package
+      # Manager instead of the source repos recorded in the lockfile. PPM
+      # serves the exact pinned versions and avoids compiling from source
+      # (which would require us to also install -dev system libraries).
+      RENV_CONFIG_REPOS_OVERRIDE: https://packagemanager.posit.co/cran/__linux__/jammy/latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libxml2-dev \
+            libfontconfig1-dev \
+            libfreetype6-dev \
+            libharfbuzz-dev \
+            libfribidi-dev \
+            libpng-dev \
+            libtiff5-dev \
+            libjpeg-dev \
+            libcairo2-dev
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
Fix the broken main build (run [28014686491](https://github.com/danhalligan/ISLRv2-solutions/actions/runs/28014686491)) where `systemfonts` failed to compile because `libfontconfig` was missing.

`setup-renv@v2` only runs `renv::restore()`; unlike `setup-r-dependencies@v2` it does not call pak to resolve and apt-install system dependencies. So `restore` was compiling CRAN packages from source against the lockfile's `cloud.r-project.org` URL and failing on missing system libs.

### Fix

1. **Set `RENV_CONFIG_REPOS_OVERRIDE`** to PPM's Linux binary mirror (`__linux__/jammy/latest`). renv now pulls the exact pinned versions as **pre-built binaries**, skipping compilation for CRAN packages entirely.
2. **Add an `apt-get` step** for the common system libs (`fontconfig`, `freetype`, `harfbuzz`, `fribidi`, `png`, `tiff`, `jpeg`, `cairo`, `xml2`, `curl`, `openssl`) so anything that does compile from source (Bioconductor packages, source-only builds) has what it needs.
3. **Pin the runner to `ubuntu-22.04`** so the PPM `jammy` URL stays in sync with the runner's libc / system libraries.

Bioconductor packages (`ggtree`, `treeio`, `BiocVersion`) still come from `bioconductor.org` per the lockfile's repos — they are `NeedsCompilation: no`, so the sysdeps step is mostly defensive for those.